### PR TITLE
Fix deprecated calls to get_class()

### DIFF
--- a/lib/Skeleton/I18n/Language.php
+++ b/lib/Skeleton/I18n/Language.php
@@ -60,7 +60,7 @@ class Language implements LanguageInterface {
 	public static function get_by_name_short($name) {
 		if (self::trait_cache_enabled()) {
 			try {
-				$object = self::cache_get(get_class() . '_' . $name);
+				$object = self::cache_get(self::class . '_' . $name);
 				return $object;
 			} catch (\Exception $e) {}
 		}


### PR DESCRIPTION
This fixes deprecation errors with PHP 8.3+.

Works For Me. But perhaps someone else should test as well.